### PR TITLE
Fix determiner and collector should not be filtered by discipline

### DIFF
--- a/app/templates/components/form-component/single-determination.hbs
+++ b/app/templates/components/form-component/single-determination.hbs
@@ -75,7 +75,6 @@
             displayField='fullName'
 
             entityType='agent'
-            filterKeys='disciplineID'
 
             itemSelected=(action 'setDeterminer')
             item=model.determiner

--- a/app/templates/partial/collector-selector.hbs
+++ b/app/templates/partial/collector-selector.hbs
@@ -15,7 +15,6 @@
     displayField='fullName'
 
     entityType='agent'
-    filterKeys='disciplineID'
 
     itemSelected=(action "createCollector")
     multiSelect=true


### PR DESCRIPTION
Fixed an issue with determiner and collector being filtered by discipline. This will cause no agent to appear if you have a collection selected.
